### PR TITLE
Created CourseRepo

### DIFF
--- a/src/main/java/gr/athtech/daem/repository/CourseRepository.java
+++ b/src/main/java/gr/athtech/daem/repository/CourseRepository.java
@@ -1,0 +1,22 @@
+package gr.athtech.daem.repository;
+
+import gr.athtech.daem.domain.Course;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CourseRepository extends JpaRepository<Course, Long> {
+
+	Optional<Course> findById(Long id);
+
+	List<Course> findByTypeOfCourse(Long id);
+
+	List<Course> findByUserId(Long id);
+
+	List<Course> findByAreaOfStudy(Long id);
+
+	List<Course> findByName(String name);
+
+}


### PR DESCRIPTION
Left a warning on FindByTypeOfCourse where it returns Optional. 
Warning: Not annotated method overrides method annotated with @NonNullApi. 
The generated ID of the entity is by default notNull whereas Optional assumes it could be null or notNull.